### PR TITLE
docs: updating command example to keep using the same example number

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ softsim fetch -a <your_api_key> -n 5678
 
 Specify output path:
 ```
-softsim fetch -a <your_api_key> -n 1000 -o "batch1"
+softsim fetch -a <your_api_key> -n 5678 -o "batch1"
 ```
 
 ### Next


### PR DESCRIPTION
the change is done since customers on free trial keep trying to fetch 1000 softsims since that is the example