### PR TITLE
ci: fix release please credentials

### DIFF
--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -1,5 +1,5 @@
----
 name: Lint commit messages
+
 on:
   pull_request:
 

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -1,7 +1,6 @@
 name: Lint commit messages
 
-on:
-  pull_request:
+on: pull_request
 
 jobs:
   commitlint:

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -9,7 +9,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         name: Checkout source code
-
       - uses: wagoid/commitlint-github-action@v5
         name: Lint commit messages
-

--- a/.github/workflows/release-bin.yml
+++ b/.github/workflows/release-bin.yml
@@ -5,7 +5,8 @@ permissions:
 
 on: 
   release:
-    types: [created]
+    types: 
+      - created
 
 jobs:
   upload-assets:

--- a/.github/workflows/release-bin.yml
+++ b/.github/workflows/release-bin.yml
@@ -4,7 +4,7 @@ permissions:
   contents: write
 
 on: 
-  release: 
+  release:
     types: [created]
 
 jobs:
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
           # Note that glob pattern is not supported yet.
           bin: softsim
@@ -31,7 +32,3 @@ jobs:
           # [default value: windows]
           # [possible values: all, unix, windows, none]
           zip: windows
-          
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,7 @@
 name: Run release-please
 
 on:
-  push:
-    branches: [master]
+  push: {branches: master}
 
 permissions:
   contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,9 @@
 name: Run release-please
 
 on:
-  push: {branches: master}
+  push: 
+    branches: 
+      - master
 
 permissions:
   contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: google-github-actions/release-please-action@v3
         with:
           release-type: rust
           package-name: ${{ github.event.repository.name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,5 @@
----
+name: Run release-please
+
 on:
   push:
     branches: [master]
@@ -7,14 +8,11 @@ permissions:
   contents: write
   pull-requests: write
 
-name: Run release-please
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: rust
-          package-name: ${{ github.event.repository.name }}
           token: ${{ secrets.GH_SS_CLI_AUTH_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
-name: General CI Build & Test Flow
-
 on: [push, pull_request]
+
+name: General CI Build & Test Flow
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,8 @@
-on: [push]
+name: General CI Build & Test Flow
 
-name: Ci
+on: 
+  push: {branches: master}
+  pull_request: {branches: master}
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,8 +1,12 @@
 name: General CI Build & Test Flow
 
 on:
-  push: {branches: master}
-  pull_request: {branches: master}
+  push: 
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,6 @@ name: General CI Build & Test Flow
 
 on:
   push: 
-    branches:
-      - master
-  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,8 +1,6 @@
 name: General CI Build & Test Flow
 
-on:
-  push:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: General CI Build & Test Flow
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,8 @@
 name: General CI Build & Test Flow
 
 on:
-  push: 
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
-on: [push, pull_request]
-
 name: General CI Build & Test Flow
+
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: General CI Build & Test Flow
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: General CI Build & Test Flow
 
-on: 
+on:
   push: {branches: master}
   pull_request: {branches: master}
 


### PR DESCRIPTION
Removing the deprecated release-please credential.
Tightening up the GitHub Actions files to allow for a more consistent file structure.