### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @onomondo/core-network-squad
+* @onomondo/softsim-team


### PR DESCRIPTION
This pull request updates the ownership assignment in the `CODEOWNERS` file to reflect the correct responsible team.

* Ownership of all files (`*`) is transferred from `@onomondo/core-network-squad` to `@onomondo/softsim-team`.