### PR TITLE
ci: use GITHUB_TOKEN instead of PAT in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           release-type: rust
           package-name: ${{ github.event.repository.name }}
-          token: ${{ secrets.GH_SS_CLI_AUTH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The practical test is just merging and watching the Actions run — it's a low-risk merge since the worst outcome is a clear 403 error you can fix by reverting the token line.