### PR TITLE
chore(deps): update actions/cache action to v6.1.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
           toolchain: stable
       - uses: taiki-e/install-action@f37bbcb2883cc6e475d39f5544f5bfbb58a725e5 # cargo-binstall
       - run: cargo binstall --no-confirm --no-symlinks sccache
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry/index/


### PR DESCRIPTION
Splits the `actions/cache` half out of the grouped major bump in #111.

| Package | Update | Change |
|---|---|---|
| [actions/cache](https://github.com/actions/cache) | major | `v5.0.5` → `v6.1.0` |

`v6.0.0` migrated the action to ESM and the `node24` runtime; `v6.1.0` adds handling for read-only cache access. The only inputs this repo uses — `path` and `key` — are unchanged in `v6.1.0`'s `action.yml`.

`v6.1.0` was released 2026-06-26, so it is past the 7-day `minimumReleaseAge` gate in `renovate.json`, and it is the current latest release.

`rust.yml` runs `on: [push]`, so pushing this branch exercised the new action.