### PR TITLE
chore(deps): update actions/checkout action to v7.0.1

### DIFF
--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -10,7 +10,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         name: Checkout source code
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed #6.2.1
         name: Lint commit messages

--- a/.github/workflows/release-bin.yml
+++ b/.github/workflows/release-bin.yml
@@ -18,7 +18,7 @@ jobs:
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1.30.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: "1G"
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v1.94.1
         with:
           toolchain: stable


### PR DESCRIPTION
Splits the `actions/checkout` half out of the grouped major bump in #111, and takes `v7.0.1` rather than the `v7.0.0` Renovate proposed (`v7.0.1` was still inside the 7-day gate when #111 was opened).

| Package | Update | Change |
|---|---|---|
| [actions/checkout](https://github.com/actions/checkout) | major | `v6.0.2` → `v7.0.1` |

`v7.0.0` breaking change: fork PRs are no longer checked out for `pull_request_target` and `workflow_run` events. Neither trigger is used in this repo — `rust.yml` is `on: [push]`, `lint-commits.yml` is `on: pull_request`, `release-bin.yml` is `on: release` — so nothing here is affected. No `with:` inputs are passed to `checkout` in any of the three workflows.

`v7.0.1` was released 2026-07-20 (past the 7-day `minimumReleaseAge` gate) and is the current latest release.